### PR TITLE
Set environment variables for Netlify deployment contexts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,12 +18,15 @@
 
 [context.production]
   command = "npm run build"
+  environment = { NEXT_PUBLIC_GRAPHQL_ENDPOINT = "https://nbx-django-production.up.railway.app/graphql", NEXT_PUBLIC_API_URL = "https://nbx-django-production.up.railway.app" }
 
 [context.deploy-preview]
   command = "npm run build"
+  environment = { NEXT_PUBLIC_GRAPHQL_ENDPOINT = "https://nbx-django-production.up.railway.app/graphql", NEXT_PUBLIC_API_URL = "https://nbx-django-production.up.railway.app" }
 
 [context.branch-deploy]
   command = "npm run build"
+  environment = { NEXT_PUBLIC_GRAPHQL_ENDPOINT = "https://nbx-django-production.up.railway.app/graphql", NEXT_PUBLIC_API_URL = "https://nbx-django-production.up.railway.app" }
 
 [[headers]]
   for = "/*"


### PR DESCRIPTION
```markdown

### Summary

- Add environment variables (`NEXT_PUBLIC_GRAPHQL_ENDPOINT` and `NEXT_PUBLIC_API_URL`) to `netlify.toml` for `production`, `deploy-preview`, and `branch-deploy` contexts.

### Testing Strategy

- Verify that the correct environment variables load during builds for each specified Netlify context.
  

### Related Issues

- None at present.

### Dependencies

- None.

### Checklist

- [ ] Code has been tested and works locally.
- [ ] Documentation has been updated (if relevant).
- [ ] All relevant issues have been addressed.

```